### PR TITLE
Switch to camel case method names

### DIFF
--- a/tts/template.d.txt
+++ b/tts/template.d.txt
@@ -8,7 +8,7 @@ export class {{.Name.UpperCamelCase.String}}TwirpClient {
   constructor (transport: twirp.Transport);
 {{$service := .}}
 {{range .Methods}}
-  {{.Name.LowerSnakeCase.String}}(
+  {{.Name.LowerCamelCase.String}}(
     request: pb.{{.Input.Name.UpperCamelCase.String}},
   ): Promise<pb.{{.Output.Name.UpperCamelCase.String}}>;
 {{end}}

--- a/tts/template.txt
+++ b/tts/template.txt
@@ -35,7 +35,7 @@ scope.{{.Name.UpperCamelCase.String}}TwirpClient =
 * @return {!Promise<!pb.{{.Output.Name.UpperCamelCase.String}}>}
 *     Promise that resolves to the response
 */
-scope.{{$service.Name.UpperCamelCase.String}}TwirpClient.prototype.{{.Name.LowerSnakeCase.String}} =
+scope.{{$service.Name.UpperCamelCase.String}}TwirpClient.prototype.{{.Name.LowerCamelCase.String}} =
     function (request) {
         return this.transport_.call('{{$service.Package.ProtoName.String}}.{{$service.Name.UpperCamelCase.String}}', '{{.Name.UpperCamelCase.String}}', request, pb.{{.Output.Name.UpperCamelCase.String}})
     };


### PR DESCRIPTION
This more closely matches the previous version of Twirp client code
generation and matches what other generators like protobuf.js do.